### PR TITLE
Removido SendResponse

### DIFF
--- a/src/Horse.StaticFiles.pas
+++ b/src/Horse.StaticFiles.pas
@@ -99,7 +99,6 @@ begin
     TMimeTypes.Default.GetFileInfo(LNormalizeFileName, LType, LKind);
     AHorseResponse.RawWebResponse.ContentType := LType;
     AHorseResponse.RawWebResponse.StatusCode := 200;
-    AHorseResponse.RawWebResponse.SendResponse;
     raise EHorseCallbackInterrupted.Create;
   end;
 


### PR DESCRIPTION
Se for utilizado algum middleware que altera o response header após o comando next, essa alteração não é enviada na resposta!

Ex: Ordem dos Middlewares

Middleware1 - altera o header após o comando next;
HorseStaticFiles -> Faz o SendResponse, então a alteração do header do Middleware1 não é enviada na resposta, pois o HorseStaticFile já enviou..